### PR TITLE
breaking: add `initTokenizer()` API method

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -42,6 +42,7 @@ const addon = bindings<{
   statementClose(stmt: NativeStatement): void;
 
   databaseOpen(path: string): NativeDatabase;
+  databaseInitTokenizer(db: NativeDatabase): void;
   databaseExec(db: NativeDatabase, query: string): void;
   databaseClose(db: NativeDatabase): void;
 
@@ -348,6 +349,13 @@ export default class Database {
     }
     this.#native = addon.databaseOpen(path);
     this.#isCacheEnabled = cacheStatements === true;
+  }
+
+  public initTokenizer(): void {
+    if (this.#native === undefined) {
+      throw new Error('Database closed');
+    }
+    addon.databaseInitTokenizer(this.#native);
   }
 
   /**

--- a/src/addon.h
+++ b/src/addon.h
@@ -27,6 +27,7 @@ class Database {
 
   static Database* FromExternal(const Napi::Value value);
   static Napi::Value Open(const Napi::CallbackInfo& info);
+  static Napi::Value InitTokenizer(const Napi::CallbackInfo& info);
   static Napi::Value Close(const Napi::CallbackInfo& info);
   static Napi::Value Exec(const Napi::CallbackInfo& info);
 

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -380,6 +380,18 @@ test('bigint mode', () => {
   ).toEqual(n);
 });
 
+test('tokenizer setup', () => {
+  db.initTokenizer();
+});
+
+test('tokenizer setup after close', () => {
+  db.close();
+  expect(() => db.initTokenizer()).toThrowError('Database closed');
+
+  // Just to fix afterEach
+  db = new Database();
+});
+
 test('signalTokenize', () => {
   expect(db.signalTokenize('a b c')).toEqual(['a', 'b', 'c']);
 });


### PR DESCRIPTION
Since sqlcipher v4.7.0, queries cannot run on an encrypted database before the decryption key is provided. FTS5 tokenizer initialization requires `SELECT` query to get the pointer to sqlite's internal APIs, so we have to move it into a separate method that the embedder would have to call.