### PR TITLE
Allow importing with exports-aware Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "exports": {
+    "types": "./dist/lib/index.d.ts",
     "import": "./dist/index.mjs",
     "require": "./dist/index.cjs"
   },


### PR DESCRIPTION
Trying to import the library could run into the following issue:

 error TS7016: Could not find a declaration file for module '@signalapp/sqlcipher'. '.../node_modules/@signalapp/sqlcipher/dist/index.mjs' implicitly has an 'any' type.
  There are types at '.../node_modules/@signalapp/sqlcipher/dist/lib/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@signalapp/sqlcipher' library may need to update its package.json or typings.

  The issue comes from mismatch where index.mjs does not automatically
  map to index.d.ts (it would have to be index.d.mts).

  The solution is to add types to export. The other "type" key could
  be removed but is left in for now for compatibility with old tsc
  versions.

The issue was discussed here:
https://github.com/microsoft/TypeScript/issues/52363

And here is an example of the similar solution in another library:
https://github.com/onsetsoftware/automerge-patcher/pull/1