### PR TITLE
Update SqliteValue to expect a Uint8Array<ArrayBuffer>

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -108,7 +108,7 @@ export type StatementParameters<Options extends StatementOptions> =
  */
 export type SqliteValue<Options extends StatementOptions> =
   | string
-  | Uint8Array
+  | Uint8Array<ArrayBuffer>
   | number
   | null
   | (Options extends { bigint: true } ? bigint : never);


### PR DESCRIPTION
I believe this is actually a requirement for Napi unless you've specifically enabled SharedArrayBuffer so I think this makes sense