### PR TITLE
Add db.setWalHook()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/
 .tmp/
 .eslintcache
 todo.md
+.vscode

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -53,6 +53,10 @@ const addon = bindings<{
     fn: (...args: ReadonlyArray<unknown>) => void,
     bigint: boolean,
   ): void;
+  databaseSetWalHook(
+    db: NativeDatabase,
+    fn: (dbName: string, pageCount: number) => void,
+  ): void;
 
   signalTokenize(value: string): Array<string>;
 
@@ -410,6 +414,13 @@ export type DatabaseOptions = Readonly<{
 }>;
 
 /**
+ * @param dbName - The name of the database that was written to.
+ * @param pageCount - The number of pages currently in the write-ahead log file,
+ *                    including those that were just committed.
+ */
+export type WalHook = (dbName: string, pageCount: number) => void;
+
+/**
  * A sqlite database class.
  */
 export default class Database {
@@ -493,6 +504,22 @@ export default class Database {
       fn,
       options.bigint === true,
     );
+  }
+
+  /**
+   * Register a callback to be invoked each time data is commited to a database
+   * in WAL mode.
+   *
+   * @param fn - function implementation
+   */
+  public setWalHook(fn: WalHook): void {
+    if (this.#native === undefined) {
+      throw new Error('Database closed');
+    }
+    if (typeof fn !== 'function') {
+      throw new TypeError('Invalid fn argument');
+    }
+    addon.databaseSetWalHook(this.#native, fn);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -35,11 +35,12 @@
   },
   "scripts": {
     "watch": "tsc --watch",
-    "build": "run-p --print-label build:ts build:esm build:cjs",
+    "build": "run-p --print-label build:ts build:esm build:cjs build:addon",
     "build:ts": "tsc",
     "build:esm": "esbuild --target=node20 --define:__dirname=undefined lib/index.ts --outfile=dist/index.mjs",
     "build:cjs": "esbuild --target=node20 --define:import.meta.url=undefined lib/index.ts --format=cjs --outfile=dist/index.cjs",
     "build:docs": "typedoc lib/index.ts --includeVersion",
+    "build:addon": "node-gyp build",
     "install": "node-gyp-build",
     "prebuildify": "prebuildify --strip --napi",
     "test": "vitest --coverage --pool threads",

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -162,9 +162,7 @@ class FunctionWrap {
 
 class WalHookWrap {
  public:
-  explicit WalHookWrap(Napi::Function fn) {
-    fn_.Reset(fn, 1);
-  }
+  explicit WalHookWrap(Napi::Function fn) { fn_.Reset(fn, 1); }
 
   static int Run(void* p_app, sqlite3* _db, const char* db_name, int n_pages) {
     auto wrap = static_cast<WalHookWrap*>(p_app);

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -158,6 +158,40 @@ class FunctionWrap {
   bool is_bigint_;
 };
 
+// WAL Hook
+
+class WalHookWrap {
+ public:
+  explicit WalHookWrap(Napi::Function fn) {
+    fn_.Reset(fn, 1);
+  }
+
+  static int Run(void* p_app, sqlite3* _db, const char* db_name, int n_pages) {
+    auto wrap = static_cast<WalHookWrap*>(p_app);
+    wrap->Call(db_name, n_pages);
+    return SQLITE_OK;
+  }
+
+ protected:
+  void Call(const char* db_name, int n_pages) {
+    auto env = fn_.Env();
+    Napi::HandleScope scope(env);
+
+    auto result = fn_.Value().Call({
+        Napi::String::New(env, db_name),
+        Napi::Number::New(env, n_pages),
+    });
+
+    // Ignore exceptions
+    if (result.IsEmpty()) {
+      env.GetAndClearPendingException();
+    }
+  }
+
+ private:
+  Napi::Reference<Napi::Function> fn_;
+};
+
 // Global Settings
 
 thread_local Napi::Reference<Napi::Function> logger_fn_;
@@ -236,6 +270,8 @@ Napi::Object Database::Init(Napi::Env env, Napi::Object exports) {
   exports["databaseExec"] = Napi::Function::New(env, &Database::Exec);
   exports["databaseCreateFunction"] =
       Napi::Function::New(env, &Database::CreateFunction);
+  exports["databaseSetWalHook"] =
+      Napi::Function::New(env, &Database::SetWalHook);
   return exports;
 }
 
@@ -250,6 +286,9 @@ Database::~Database() {
   if (handle_ == nullptr) {
     return;
   }
+
+  delete wal_hook_wrap_;
+  wal_hook_wrap_ = nullptr;
 
   int r = sqlite3_close(handle_);
   if (r != SQLITE_OK) {
@@ -342,6 +381,9 @@ Napi::Value Database::Close(const Napi::CallbackInfo& info) {
   }
   db->statements_.clear();
 
+  delete db->wal_hook_wrap_;
+  db->wal_hook_wrap_ = nullptr;
+
   int r = sqlite3_close(db->handle_);
   if (r != SQLITE_OK) {
     return db->ThrowSqliteError(env, r);
@@ -408,6 +450,32 @@ Napi::Value Database::CreateFunction(const Napi::CallbackInfo& info) {
     delete fn_wrap;
     return db->ThrowSqliteError(env, r);
   }
+  return Napi::Value();
+}
+
+Napi::Value Database::SetWalHook(const Napi::CallbackInfo& info) {
+  auto env = info.Env();
+
+  auto db = FromExternal(info[0]);
+  auto fn = info[1].As<Napi::Function>();
+
+  assert(fn.IsFunction());
+
+  if (db == nullptr) {
+    return Napi::Value();
+  }
+
+  if (db->handle_ == nullptr) {
+    NAPI_THROW(Napi::Error::New(env, "Database closed"), Napi::Value());
+  }
+
+  auto wal_wrap = new WalHookWrap(fn);
+
+  delete db->wal_hook_wrap_;
+  db->wal_hook_wrap_ = wal_wrap;
+
+  sqlite3_wal_hook(db->handle_, WalHookWrap::Run, wal_wrap);
+
   return Napi::Value();
 }
 

--- a/src/addon.h
+++ b/src/addon.h
@@ -9,6 +9,7 @@
 #include "sqlite3.h"
 
 class Statement;
+class WalHookWrap;
 
 class Database {
  public:
@@ -31,6 +32,7 @@ class Database {
   static Napi::Value Close(const Napi::CallbackInfo& info);
   static Napi::Value Exec(const Napi::CallbackInfo& info);
   static Napi::Value CreateFunction(const Napi::CallbackInfo& info);
+  static Napi::Value SetWalHook(const Napi::CallbackInfo& info);
 
   fts5_api* GetFTS5API(Napi::Env env);
 
@@ -45,6 +47,8 @@ class Database {
   // All currently open statements for this database. Used to close all open
   // statements when closing the database.
   std::list<Statement*> statements_;
+
+  WalHookWrap* wal_hook_wrap_ = nullptr;
 };
 
 class AutoResetStatement {

--- a/test/disk.test.ts
+++ b/test/disk.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { expect, test, beforeEach, afterEach } from 'vitest';
+import { expect, test, describe, beforeEach, afterEach, vi } from 'vitest';
 
 import Database from '../lib/index.js';
 
@@ -64,4 +64,81 @@ test.each([[false], [true]])('ciphertext=%j', (ciphertext) => {
     .get({ id });
 
   expect(row).toEqual({ name: 'Adam', value: 'Sandler' });
+});
+
+describe('setWalHook', () => {
+  beforeEach(() => {
+    db.pragma('journal_mode = WAL');
+    db.exec('CREATE TABLE t (a INTEGER)');
+  });
+
+  test('calls hook after WAL commit', () => {
+    const hook = vi.fn();
+    db.setWalHook(hook);
+
+    db.prepare('INSERT INTO t (a) VALUES (1)').run();
+
+    expect(hook).toHaveBeenCalledOnce();
+    expect(hook).toHaveBeenCalledWith('main', expect.any(Number));
+  });
+
+  test('hook receives page count > 0', () => {
+    let pageCount: number | null = null;
+    db.setWalHook((_dbName, n) => {
+      pageCount = n;
+    });
+
+    db.prepare('INSERT INTO t (a) VALUES (1)').run();
+
+    expect(pageCount).toBeGreaterThan(0);
+  });
+
+  test('hook fires once per commit', () => {
+    const hook = vi.fn();
+    db.setWalHook(hook);
+
+    db.transaction(() => {
+      db.prepare('INSERT INTO t (a) VALUES (1)').run();
+      db.prepare('INSERT INTO t (a) VALUES (2)').run();
+    })();
+
+    expect(hook).toHaveBeenCalledOnce();
+  });
+
+  test('replaces previous hook', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    db.setWalHook(first);
+    db.setWalHook(second);
+
+    db.prepare('INSERT INTO t (a) VALUES (1)').run();
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+  });
+
+  test('silently ignores exceptions thrown by hook', () => {
+    let called = false;
+    db.setWalHook(() => {
+      called = true;
+      throw new Error('hook error');
+    });
+
+    expect(() =>
+      db.prepare('INSERT INTO t (a) VALUES (1)').run(),
+    ).not.toThrow();
+    expect(called).toBe(true);
+  });
+
+  test('throws when database is closed', () => {
+    db.close();
+    expect(() => db.setWalHook(vi.fn())).toThrowError('Database closed');
+    db = new Database(join(dir, 'db2.sqlite'));
+  });
+
+  test('throws for invalid argument', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => db.setWalHook(123 as any)).toThrowError('Invalid fn argument');
+  });
 });


### PR DESCRIPTION
This adds the ability to call `sqlite3_wal_hook()` to setup a JS callback.

> The callback is invoked by SQLite after the commit has taken place and the associated write-lock on the database released, so the implementation may read, write or [checkpoint](https://sqlite.org/wal.html#ckpt) the database as required.

Importantly, setting your own WAL hook replaces/disables `sqlite3_wal_autocheckpoint`:

> _From [sqlite3_wal_hook()](https://sqlite.org/c3ref/wal_hook.html)_
> 
> A single database handle may have at most a single write-ahead log callback registered at one time. Calling `sqlite3_wal_hook()` replaces the default behavior or previously registered write-ahead log callback.

> _From [sqlite3_wal_autocheckpoint](https://sqlite.org/c3ref/wal_autocheckpoint.html)_
> 
> The `sqlite3_wal_autocheckpoint(D,N)` is a wrapper around `sqlite3_wal_hook()` [...]

If the JS callback throws, the `WalHookWrap::Call` function will swallow the exception and return `SQLITE_OK`. The alternative is that that the statement that triggered the commit would throw.

> The callback function should normally return [SQLITE_OK](https://sqlite.org/rescode.html#ok). If an error code is returned, that error will propagate back up through the SQLite code base to cause the statement that provoked the callback to report an error, though the commit will have still occurred.

The implementation is basically the same as `db.createFunction()` but it differs in how it gets cleaned up since we don't have the `xFinal` param to call the destructor at `FunctionWrap::Final`. Instead its stored at `Database::wal_hook_wrap_` which then needs to be cleaned up on database close.

